### PR TITLE
CLOUD-888 added content type for the image creation request to avoid …

### DIFF
--- a/src/main/groovy/com/sequenceiq/cloud/azure/client/AzureClientUtil.groovy
+++ b/src/main/groovy/com/sequenceiq/cloud/azure/client/AzureClientUtil.groovy
@@ -1,5 +1,4 @@
 package com.sequenceiq.cloud.azure.client
-
 import groovyx.net.http.HttpResponseDecorator
 import groovyx.net.http.RESTClient
 import org.apache.commons.logging.Log
@@ -70,8 +69,9 @@ class AzureClientUtil {
         )
         client.put(
                 path: targetImageUri,
-                requestContentType: TEXT
-                // can't use XML here, because Azure REST Server returns some extra characters
+                requestContentType: TEXT,
+                contentType: TEXT
+                // can't use XML here, because Azure REST Server returns some extra characters (the BOM)
                 // and causes the XML parser to throw "org.xml.sax.SAXParseException: Content is not allowed in prolog"
         )
     }


### PR DESCRIPTION
* Added contentType to avoid sax parser exception due to the BOM (https://en.wikipedia.org/wiki/Byte_order_mark) in the response returned by Azure

@keyki please review it